### PR TITLE
Say something when ready.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -38,4 +38,6 @@ if [ -n "$USERNAME" ] && [ -n "$EMAIL" ] && [ -n "$PASSWORD" ]; then
   chown git:git -R /home/git/.docker/
 fi
 
+echo "Builder started serving."
+
 exec /usr/sbin/sshd -D


### PR DESCRIPTION
User doesn't know if it's still installing something with the old output:

```
2016-04-21T14:17:42.000Z [1]: ~~ Kontena App Builder ~~
2016-04-21T14:17:42.000Z [1]: => Found authorized keys
2016-04-21T14:17:42.000Z [1]: => Installing requested version of Kontena cli: 0.11.7
2016-04-21T14:17:49.000Z [1]: Successfully installed kontena-cli-0.11.7
2016-04-21T14:17:49.000Z [1]: 1 gem installed
```

Now the user knows:

```
2016-04-21T14:17:42.000Z [1]: ~~ Kontena App Builder ~~
2016-04-21T14:17:42.000Z [1]: => Found authorized keys
2016-04-21T14:17:42.000Z [1]: => Installing requested version of Kontena cli: 0.11.7
2016-04-21T14:17:49.000Z [1]: Successfully installed kontena-cli-0.11.7
2016-04-21T14:17:49.000Z [1]: 1 gem installed
2016-04-21T14:17:49.000Z [1]: Builder started serving.
```
